### PR TITLE
Fix alternate URL generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,10 +193,10 @@ func processRequest(msg *expectedMessage, logger *logrus.Entry) {
 
 	// now check for the other http
 	var alternateURL string
-	if strings.HasPrefix(msg.URL, "http") {
-		alternateURL = "https" + msg.URL[4:]
-	} else {
+	if strings.HasPrefix(msg.URL, "https") {
 		alternateURL = "http" + msg.URL[5:]
+	} else {
+		alternateURL = "https" + msg.URL[4:]
 	}
 
 	requestID := rand.Int31()


### PR DESCRIPTION
Right now alternate URL generation only works for HTTP requests, since the prefix check for "http" also matches "https://..." and ends up generating "httpss://..." as an alternate.