### PR TITLE
use the Hostname() not the Host when doing IP lookup

### DIFF
--- a/timing/tls.go
+++ b/timing/tls.go
@@ -14,9 +14,9 @@ import (
 func addTLSInfo(req *http.Request, res *timingResults, log *logrus.Entry) {
 	res.IsHTTPS = false
 	if req.URL.Scheme == "https" {
-		ips, err := net.LookupIP(req.URL.Host)
+		ips, err := net.LookupIP(req.URL.Hostname())
 		if err != nil {
-			log.WithError(err).Warnf("Failed to resolve %s to an IP", req.URL.Host)
+			log.WithError(err).Warnf("Failed to resolve %s to an IP", req.URL.Hostname())
 			res.ErrorCode = "failed_tls_ip_lookup"
 			res.ErrorMsg = err.Error()
 			return


### PR DESCRIPTION
We were getting
```
WARN[0002] Failed to resolve parafuzo.com:443 to an IP   error="lookup parafuzo.com:443: invalid domain name" tested_url="https://parafuzo.com:443/" url="http://parafuzo.com"
```

Which is b/c it was looking up the host:port for an IP, which isn't right. This should fix it.

Note: this shouldn't have caused timing differences, just that in some cases we would get errors